### PR TITLE
Do not raise errors if the status is unknown

### DIFF
--- a/src/technove/models.py
+++ b/src/technove/models.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-from technove.exceptions import TechnoVEError
-
 
 class Status(Enum):
     """Describes the status of a TechnoVE station."""
@@ -29,8 +27,7 @@ class Status(Enum):
         if status in statuses:
             return statuses[status]
 
-        error_message = f"The status code {status} is not a valid status."
-        raise TechnoVEError(error_message)
+        return Status.UNKNOWN
 
 
 class Station:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,7 @@
 """Tests for `technove.TechnoVE`."""
 
 
-import pytest
-
-from technove import Status, TechnoVEError
+from technove import Status
 
 
 def test_status_build() -> None:
@@ -13,5 +11,4 @@ def test_status_build() -> None:
 
 def test_status_build_unknown() -> None:
     """Test status build with an unknown status code."""
-    with pytest.raises(TechnoVEError):
-        Status.build(42)
+    assert Status.build(42) == Status.UNKNOWN


### PR DESCRIPTION
Currently, receiving a status that is not in the list of known status will raise an error.
This changes that behaviour to make the status unknown instead. This would prevent receiving updates from the other properties just because the status is wrong.