### PR TITLE
Revert status type to integer and fix parsing logic

### DIFF
--- a/src/technove/models.py
+++ b/src/technove/models.py
@@ -40,17 +40,15 @@ class Status(Enum):
     HIGH_TARIFF_PERIOD = "high_tariff_period"
 
     @classmethod
-    def build(cls: type[Status], status: Any | None) -> Status:
-        """Parse a status value from the TechnoVE API into a Status object.
+    def build(cls: type[Status], status: int | None) -> Status:
+        """Parse the status code int to a Status object.
 
-        The API returns the status as a single ASCII character string (e.g. 'A',
-        'B', 'C'). This method accepts either the raw character string or its
-        integer ordinal equivalent.
+        The API returns the status as an integer representing the ASCII
+        character ordinal (e.g. 65 for 'A', 66 for 'B').
 
         Args:
         ----
-            status: The raw status value from the API. May be a single-character
-                string, an integer ordinal, or None.
+            status: The raw status integer value from the API, or None.
 
         Returns:
         -------
@@ -58,27 +56,20 @@ class Status(Enum):
             values.
 
         """
-        if isinstance(status, str):
-            code = ord(status) if len(status) == 1 else None
-        elif isinstance(status, int):
-            code = status
-        else:
-            code = None
+        statuses = {
+            None: Status.UNKNOWN,
+            ord("A"): Status.UNPLUGGED,  # 65
+            ord("B"): Status.PLUGGED_WAITING,  # 66
+            ord("C"): Status.PLUGGED_CHARGING,  # 67
+            ord("D"): Status.VENTILATION_REQUIRED,  # 68
+            ord("E"): Status.PILOT_FAULT,  # 69
+            ord("F"): Status.EVSE_FAULT,  # 70
+            ord("H"): Status.GROUND_FAULT,  # 72
+            ord("S"): Status.OUT_OF_ACTIVATION_PERIOD,  # 83
+            ord("T"): Status.HIGH_TARIFF_PERIOD,  # 84
+        }
 
-        return _STATUS_MAP.get(code, cls.UNKNOWN)
-
-
-_STATUS_MAP: dict[int | None, Status] = {
-    ord("A"): Status.UNPLUGGED,  # 65
-    ord("B"): Status.PLUGGED_WAITING,  # 66
-    ord("C"): Status.PLUGGED_CHARGING,  # 67
-    ord("D"): Status.VENTILATION_REQUIRED,  # 68
-    ord("E"): Status.PILOT_FAULT,  # 69
-    ord("F"): Status.EVSE_FAULT,  # 70
-    ord("H"): Status.GROUND_FAULT,  # 72
-    ord("S"): Status.OUT_OF_ACTIVATION_PERIOD,  # 83
-    ord("T"): Status.HIGH_TARIFF_PERIOD,  # 84
-}
+        return statuses.get(status, Status.UNKNOWN)
 
 
 class Station:

--- a/src/technove/models.py
+++ b/src/technove/models.py
@@ -56,23 +56,24 @@ class Status(Enum):
             values.
 
         """
-        statuses = {
-            None: Status.UNKNOWN,
-            ord("A"): Status.UNPLUGGED,  # 65
-            ord("B"): Status.PLUGGED_WAITING,  # 66
-            ord("C"): Status.PLUGGED_CHARGING,  # 67
-            ord("D"): Status.VENTILATION_REQUIRED,  # 68
-            ord("E"): Status.PILOT_FAULT,  # 69
-            ord("F"): Status.EVSE_FAULT,  # 70
-            ord("H"): Status.GROUND_FAULT,  # 72
-            ord("S"): Status.OUT_OF_ACTIVATION_PERIOD,  # 83
-            ord("T"): Status.HIGH_TARIFF_PERIOD,  # 84
-        }
-
         if not isinstance(status, int) and status is not None:
             return Status.UNKNOWN
 
-        return statuses.get(status, Status.UNKNOWN)
+        return _STATUS_MAP.get(status, Status.UNKNOWN)
+
+
+_STATUS_MAP: dict[int | None, Status] = {
+    None: Status.UNKNOWN,
+    ord("A"): Status.UNPLUGGED,  # 65
+    ord("B"): Status.PLUGGED_WAITING,  # 66
+    ord("C"): Status.PLUGGED_CHARGING,  # 67
+    ord("D"): Status.VENTILATION_REQUIRED,  # 68
+    ord("E"): Status.PILOT_FAULT,  # 69
+    ord("F"): Status.EVSE_FAULT,  # 70
+    ord("H"): Status.GROUND_FAULT,  # 72
+    ord("S"): Status.OUT_OF_ACTIVATION_PERIOD,  # 83
+    ord("T"): Status.HIGH_TARIFF_PERIOD,  # 84
+}
 
 
 class Station:

--- a/src/technove/models.py
+++ b/src/technove/models.py
@@ -69,6 +69,9 @@ class Status(Enum):
             ord("T"): Status.HIGH_TARIFF_PERIOD,  # 84
         }
 
+        if not isinstance(status, int) and status is not None:
+            return Status.UNKNOWN
+
         return statuses.get(status, Status.UNKNOWN)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,8 +8,6 @@ def test_status_build_plugged_charging() -> None:
     assert Status.build(67) == Status.PLUGGED_CHARGING
 
 
-
-
 # ---------------------------------------------------------------------------
 # Edge / fallback cases
 # ---------------------------------------------------------------------------
@@ -20,8 +18,6 @@ def test_status_build_unknown_int() -> None:
     assert Status.build(42) == Status.UNKNOWN
 
 
-
-
 def test_status_build_none() -> None:
     """None returns UNKNOWN."""
     assert Status.build(None) == Status.UNKNOWN
@@ -29,4 +25,4 @@ def test_status_build_none() -> None:
 
 def test_status_build_unhashable_type() -> None:
     """An unhashable malformed value returns UNKNOWN without raising."""
-    assert Status.build(["A"]) == Status.UNKNOWN
+    assert Status.build(["A"]) == Status.UNKNOWN  # type: ignore[arg-type]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,9 +8,6 @@ def test_status_build_plugged_charging() -> None:
     assert Status.build(67) == Status.PLUGGED_CHARGING
 
 
-def test_status_build_from_string() -> None:
-    """build() accepts the raw API single-character string."""
-    assert Status.build("B") == Status.PLUGGED_WAITING
 
 
 # ---------------------------------------------------------------------------
@@ -23,9 +20,6 @@ def test_status_build_unknown_int() -> None:
     assert Status.build(42) == Status.UNKNOWN
 
 
-def test_status_build_unknown_string() -> None:
-    """A multi-character string that is not a single ASCII state returns UNKNOWN."""
-    assert Status.build("1234") == Status.UNKNOWN
 
 
 def test_status_build_none() -> None:


### PR DESCRIPTION
In PR #16, the `status` field parsing was changed to expect strings (like 'A', 'B', etc.), but the TechnoVE API actually returns these as integers (ASCII ordinals, e.g., `65` for 'A'). This led to a regression when processing real device data.

This PR reverts the `status` field in `Status.build` to correctly handle `int` values while maintaining the expanded set of status codes (D, E, F, H, S, T).

## Changes
- **Modified** `src/technove/models.py`:
    - Updated `Status.build` to accept `int | None` instead of `Any`.
    - Removed logic that parsed single-character strings, as the API provides integers.
    - Simplified the mapping using `ord()` constants (e.g., `ord("A")`) for readability while remaining backward compatible with the integer-based API.
- **Modified** `tests/test_models.py`:
    - Removed tests that used string inputs for status building.
    - Verified that integer inputs (like `67` for charging) still return the correct enum member.


